### PR TITLE
README: swap order of ${pkgs.system} and legacyPackages

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Add this flake as an input
 ```nix
 programs.spicetify =
    let
-     spicePkgs = inputs.spicetify-nix.${pkgs.system}.legacyPackages;
+     spicePkgs = inputs.spicetify-nix.legacyPackages.${pkgs.system};
    in
    {
      enable = true;


### PR DESCRIPTION
6cbf378 introduced a change where legacyPackages and system were swapped. The flake exposes legacyPackages.${system}, not ${system}.legacyPackages.