### PR TITLE
improve snippet names

### DIFF
--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -25,10 +25,7 @@ in
   snippets = lib.pipe ./snippets.json [
     lib.importJSON
     (map (x: {
-      name = lib.pipe x.preview [
-        (lib.removePrefix "resources/assets/snippets/")
-        (x: builtins.substring 0 ((builtins.stringLength x) - 4) x)
-      ];
+      name = with lib; pipe x.preview [(splitString ".") init concatStrings toLower baseNameOf];
       value = x.code;
     }))
     builtins.listToAttrs


### PR DESCRIPTION
toLower is needed because capital names are misleading
![image](https://github.com/user-attachments/assets/7f128bbc-876b-49cd-a1e1-6317d9ab7d16)