### PR TITLE
Fixed reference to systemPackages in home-manager module

### DIFF
--- a/modules/homeManager.nix
+++ b/modules/homeManager.nix
@@ -35,7 +35,7 @@ in
     })
 
     (lib.mkIf (!cfg.dontInstall) {
-      environment.systemPackages = cfg.createdPackages;
+      home.packages = cfg.createdPackages;
     })
   ];
 }


### PR DESCRIPTION
There is a reference to the environment.systemPackages Attribute in the home-manager module (#253). I haven't rly looked thoroughly at the codebase, but I think what you wanted to write was home.packages. I tested it on my machine and my flake builds again. Thanks for maintaining this btw :)