### PR TITLE
feat: add `coverAmbience` & `sleepTimer` extensions

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -255,6 +255,14 @@ Rate your music out of 5 stars
 
 Simply displays the time remaining in the current queue.
 
+### coverAmbience
+
+Produces a lovely aesthetic glow from the currently playing album cover.
+
+### sleepTimer
+
+Ported from mobile, automatically pause music after a certain number of minutes or songs.
+
 ### simpleBeautifulLyrics
 
 Enhance your full-screen song lyrics experience with this simple theme for

--- a/pkgs/extensions.nix
+++ b/pkgs/extensions.nix
@@ -184,6 +184,16 @@ let
     name = "QueueTime.js";
   };
 
+  coverAmbience = {
+    src = "${sources.theblockbusterSrc}/CoverAmbience";
+    name = "CoverAmbience.js";
+  };
+
+  sleepTimer = {
+    src = "${sources.theblockbusterSrc}/SleepTimer";
+    name = "SleepTimer.js";
+  }
+
   simpleBeautifulLyrics = {
     src = "${sources.kamilooSrc}/extensions/simple-beautiful-lyrics/dist";
     name = "simple-beautiful-lyrics.js";
@@ -296,6 +306,8 @@ in
       oneko
       starRatings
       queueTime
+      coverAmbience
+      sleepTimer
       simpleBeautifulLyrics
       catJamSynced
     ]
@@ -321,5 +333,7 @@ in
 // (mkExtAlias "oneko.js" oneko)
 // (mkExtAlias "starRatings.js" starRatings)
 // (mkExtAlias "queueTime.js" queueTime)
+// (mkExtAlias "coverAmbience.js" coverAmbience)
+// (mkExtAlias "sleepTimer.js" sleepTimer)
 // (mkExtAlias "simpleBeautifulLyrics.js" simpleBeautifulLyrics)
 // (mkExtAlias "catJamSynced.js" catJamSynced)


### PR DESCRIPTION
This adds 2 extensions (`coverAmbience` & `sleepTimer`) from Theblockbuster1's spicetify-extensions repository. As their queueTime extension was already included here, I see no reason to not add these 2 aswell!