### PR TITLE
Add commas to PR sections of docs/{themes, extensions, custom-apps}

### DIFF
--- a/docs/custom-apps.md
+++ b/docs/custom-apps.md
@@ -24,7 +24,7 @@ programs.spicetify.enabledCustomApps= [
 ];
 ```
 
-Almost all customApp PR's will be merged quickly view the git history of
+Almost all customApp PR's will be merged quickly, view the git history of
 /pkgs/apps.nix for PR examples
 
 ## Official Apps

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -23,7 +23,7 @@ programs.spicetify.enabledExtensions = [
 ];
 ```
 
-Almost all extension PR's will be merged quickly view the git history of
+Almost all extension PR's will be merged quickly, view the git history of
 /pkgs/extensions.nix for PR examples
 
 ## Official Extensions

--- a/docs/themes.md
+++ b/docs/themes.md
@@ -31,7 +31,7 @@ programs.spicetify.theme = {
 }
 ```
 
-Almost all theme PR's will be merged quickly view the git history of
+Almost all theme PR's will be merged quickly, view the git history of
 /pkgs/themes.nix for PR examples
 
 ## Official Themes


### PR DESCRIPTION
Separate sentence parts for these sections (disambiguates and reads a bit more fluently)