### PR TITLE
Remove comment about custom-app names ending with .js

### DIFF
--- a/docs/custom-apps.md
+++ b/docs/custom-apps.md
@@ -18,7 +18,6 @@ programs.spicetify.enabledCustomApps= [
         rev = "";
         hash = "";
       };
-      # The actual file name of the customApp usually ends with .js
       name = "";
   })
 ];


### PR DESCRIPTION
This comment was most likely copy-pasted from the extensions page. In contrast with extensions, custom apps usually don't end with .js (at least I haven't seen any that do, and being names for directories instead of .js files they also don't have any reason to). Examples:
- https://github.com/Pithaya/spicetify-apps/tree/main/custom-apps/{better-local-files, eternal-jukebox, playlist-maker}
- https://github.com/harbassan/spicetify-apps/tree/main/projects/{library, stats}
- https://github.com/Konsl/spicetify-visualizer