### PR TITLE
fix lyrics path

### DIFF
--- a/pkgs/extensions.nix
+++ b/pkgs/extensions.nix
@@ -160,7 +160,7 @@ let
   };
 
   beautifulLyrics = {
-    src = "${sources.beautifulLyricsSrc}/Builds/Release";
+    src = "${sources.beautifulLyricsSrc}/Extension/Builds/Release";
     name = "beautiful-lyrics.mjs";
   };
 


### PR DESCRIPTION
The lyrics plugin failed to build

```
spotify-wrapper> Wrapping cursor binary...
spotify-wrapper> cp: cannot stat '/nix/store/4c5iijkardf3fhn232mmf4dgv59n6y50-source/Builds/Release/beautiful-lyrics.mjs': No such file or directory
error: builder for '/nix/store/i40fw1cmaa0z5lsq6vq6kkj1qzykbcxl-spicetify-text.drv' failed with exit code 1;
       last 24 log lines:
       > Running phase: unpackPhase
       > Parallel unsquashfs: Using 8 processors
       > 107 inodes (2838 blocks) to write
       >
       >
       >
       > created 106 files
       > created 10 directories
       > created 1 symlink
       > created 0 devices
       > created 0 fifos
       > created 0 sockets
       > created 0 hardlinks
       > Running phase: patchPhase
       > Running phase: updateAutotoolsGnuConfigScriptsPhase
       > Running phase: configurePhase
       > no configure script, doing nothing
       > Running phase: buildPhase
       > no Makefile or custom buildPhase, doing nothing
       > Running phase: glibPreInstallPhase
       > Running phase: glibPreInstallPhase
       > Running phase: installPhase
       > Wrapping cursor binary...
       > cp: cannot stat '/nix/store/4c5iijkardf3fhn232mmf4dgv59n6y50-source/Builds/Release/beautiful-lyrics.mjs': No such file or directory
       For full logs, run 'nix log /nix/store/i40fw1cmaa0z5lsq6vq6kkj1qzykbcxl-spicetify-text.drv'.
error: 1 dependencies of derivation '/nix/store/mgvv056q8cgaaxnw8ydmc8x26n3crdi3-system-path.drv' failed to build
error: 1 dependencies of derivation '/nix/store/477m52kl4cki9nr0vsx3sgaiw4w1dhnj-spicetify-text_fish-completions.drv' failed to build
error: 1 dependencies of derivation '/nix/store/aa7p2js2yy97aki39s36icx8q80pr5nl-etc.drv' failed to build
error: 1 dependencies of derivation '/nix/store/d9kaws1ilf7cgywdb28zbpv60g9fn35r-dbus-1.drv' failed to build
error: 1 dependencies of derivation '/nix/store/0zr71fanfwi8y0xaq7fc3s6627nx9lji-X-Restart-Triggers-polkit.drv' failed to build
error: 1 dependencies of derivation '/nix/store/9rm8hfkrwzwpbf776la1jcqkm1kmnn6b-system_fish-completions.drv' failed to build
error: 1 dependencies of derivation '/nix/store/jjw7y89wclvfhmzw3ni2nrcnvvz3lyc2-nixos-system-loneros-26.05.20260124.5232575.drv' failed to build
┏━ 1 Errors:
┃ error: builder for '/nix/store/i40fw1cmaa0z5lsq6vq6kkj1qzykbcxl-spicetify-text.drv' failed with exit code 1;
┃        last 24 log lines:
┃        > Running phase: unpackPhase
┃        > Parallel unsquashfs: Using 8 processors
┃        > 107 inodes (2838 blocks) to write
┃        >
┃        >
┃        >
┃        > created 106 files
┃        > created 10 directories
┃        > created 1 symlink
┃        > created 0 devices
┃        > created 0 fifos
┃        > created 0 sockets
┃        > created 0 hardlinks
┃        > Running phase: patchPhase
┃        > Running phase: updateAutotoolsGnuConfigScriptsPhase
┃        > Running phase: configurePhase
┃        > no configure script, doing nothing
┃        > Running phase: buildPhase
┃        > no Makefile or custom buildPhase, doing nothing
┃        > Running phase: glibPreInstallPhase
┃        > Running phase: glibPreInstallPhase
┃        > Running phase: installPhase
┃        > Wrapping cursor binary...
┃        > cp: cannot stat '/nix/store/4c5iijkardf3fhn232mmf4dgv59n6y50-source/Builds/Release/beautiful-lyrics.mjs': No such file or d…
┃        For full logs, run 'nix log /nix/store/i40fw1cmaa0z5lsq6vq6kkj1qzykbcxl-spicetify-text.drv'.
┣━ Dependency Graph:
┃ ┌─ ⏸ activate waiting for 1 ⚠ 7 ⏵
┃ │     ┌─ ⏸ unit-dbus.service waiting for 1 ⚠ 7 ⏵
┃ │  ┌─ ⏸ user-units
┃ │  ├─ ⏸ system_fish-completions waiting for 1 ⚠ 7 ⏵
┃ │  │     ┌─ ⏸ X-Restart-Triggers-polkit waiting for 1 ⚠ 7 ⏵
┃ │  │  ┌─ ⏸ unit-polkit.service
┃ │  │  │                 ┌─ ⏵ python3.13-pygame-ce-2.5.6 (buildPhase) ⏱ 24s
┃ │  │  │              ┌─ ⏸ python3-3.13.11-env
┃ │  │  │           ┌─ ⏸ wayclick-1.0.0
┃ │  │  │           │  ┌─ ⏵ niri-blur-25.11.0-feat-blur-vendor ⏱ 35s (∅ 14s)
┃ │  │  │           ├─ ⏸ niri-blur-25.11.0-feat-blur
┃ │  │  │           ├─ ⏵ fish-4.3.3 (buildPhase) ⏱ 36s (∅ 3m30s)
┃ │  │  │           ├─ ⏵ folo-1.0.0 (configurePhase) ⏱ 39s (∅ 13m3s)
┃ │  │  │           ├─ ⏵ incus-client-6.21.0 (buildPhase) ⏱ 42s
┃ │  │  │           ├─ ⏵ fabric-cli-0.0.1 (buildPhase) ⏱ 45s (∅ 20s)
┃ │  │  │           ├─ ⚠ spicetify-text failed with exit code 1 after ⏱ 14s in installPhase
┃ │  │  │        ┌─ ⏸ system-path
┃ │  │  │     ┌─ ⏸ dbus-1
┃ │  │  │  ┌─ ⏸ X-Restart-Triggers-dbus
┃ │  │  ├─ ⏸ unit-dbus.service
┃ │  ├─ ⏸ system-units
┃ ├─ ⏸ etc
┃ ├─ ⏵ linux-x86_64-unknown-linux-gnu-6.18.7 (unpackPhase) ⏱ 45s (∅ 3h9m4s)
┃ ⏸ nixos-system-loneros-26.05.20260124.5232575
┣━━━ Builds
┗━ ∑ ⏵ 7 │ ✔ 10 │ ⏸ 542 │ ⚠ Exited after 1 build failures at 02:18:45 after 1m51s
Error:
   0: Failed to build configuration
   1: Command exited with status Exited(1)

Location:
   src/commands.rs:693
```