### PR TITLE
fix(npins): update version assertion to 8 to match sources.json

### DIFF
--- a/pkgs/npins/sources.nix
+++ b/pkgs/npins/sources.nix
@@ -93,7 +93,7 @@ builtins.mapAttrs
     let
       json = lib.importJSON ./sources.json;
     in
-    assert lib.assertMsg (json.version == 7) ''
+    assert lib.assertMsg (json.version == 8) ''
       npins version mismatch!
     '';
     json.pins


### PR DESCRIPTION
This PR fixes the 'npins version mismatch' evaluation error introduced in fe9f9bcd4d35876a89f93aff5a6ad2512cfd15d8 by updating the version check in sources.nix from 7 to 8 to match sources.json. Fixes #362.