### PR TITLE
refactor: add homeModules flake output alias

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -1,19 +1,17 @@
-self:
-builtins.listToAttrs (
-  map
+self: let
+  modules = builtins.listToAttrs (
+    map
     (x: {
       name = "${x}Modules";
-      value =
-        let
-          imports = [
-            (import ./common.nix self)
-            ./${x}.nix
-          ];
-        in
-        {
-          default = { inherit imports; };
-          spicetify = { inherit imports; };
-        };
+      value = let
+        imports = [
+          (import ./common.nix self)
+          ./${x}.nix
+        ];
+      in {
+        default = {inherit imports;};
+        spicetify = {inherit imports;};
+      };
     })
     [
       "nixos"
@@ -21,4 +19,9 @@ builtins.listToAttrs (
       "darwin"
       "hjem"
     ]
-)
+  );
+in
+  modules
+  // {
+    homeModules = modules.homeManagerModules;
+  }

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -1,27 +1,35 @@
-self: let
-  modules = builtins.listToAttrs (
-    map
-    (x: {
-      name = "${x}Modules";
-      value = let
-        imports = [
-          (import ./common.nix self)
-          ./${x}.nix
-        ];
-      in {
+self:
+builtins.listToAttrs (builtins.concatLists (
+  map
+  (
+    target: let
+      imports = [
+        (import ./common.nix self)
+        ./${target.file}.nix
+      ];
+      value = {
         default = {inherit imports;};
         spicetify = {inherit imports;};
       };
-    })
-    [
-      "nixos"
-      "homeManager"
-      "darwin"
-      "hjem"
-    ]
-  );
-in
-  modules
-  // {
-    homeModules = modules.homeManagerModules;
-  }
+    in
+      map (name: {inherit name value;}) target.outputs
+  )
+  [
+    {
+      file = "nixos";
+      outputs = ["nixosModules"];
+    }
+    {
+      file = "homeManager";
+      outputs = ["homeManagerModules" "homeModules"];
+    }
+    {
+      file = "darwin";
+      outputs = ["darwinModules"];
+    }
+    {
+      file = "hjem";
+      outputs = ["hjemModules"];
+    }
+  ]
+))


### PR DESCRIPTION
What this PR does, it is adds the homeModules alias alongside the homeManagerModules