### PR TITLE
themes: fix Comfy JavaScript separator

### DIFF
--- a/pkgs/themes.nix
+++ b/pkgs/themes.nix
@@ -226,7 +226,7 @@
       ];
       extraCommands = ''
         # remove the auto-update functionality
-        echo "\n" >> ./Extensions/theme.js
+        printf '\n' >> ./Extensions/theme.js
         cat ./Themes/Comfy/theme.script.js >> ./Extensions/theme.js
       '';
     };


### PR DESCRIPTION
Replace `echo "\n"` with `printf "\n"` so the generated Comfy extension contains a real newline rather than an invalid JavaScript token.

Validation: built the generated extension and ran `node --check`.