### PR TITLE
refactor(fetcher): clean up, make idiomatic

### DIFF
--- a/pkgs/fetcher/Cargo.lock
+++ b/pkgs/fetcher/Cargo.lock
@@ -167,15 +167,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
-name = "convert_case"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -402,8 +393,8 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 name = "fetcher"
 version = "0.1.0"
 dependencies = [
- "convert_case",
  "futures",
+ "heck",
  "octocrab",
  "serde",
  "serde_json",
@@ -1965,12 +1956,6 @@ name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "untrusted"

--- a/pkgs/fetcher/Cargo.lock
+++ b/pkgs/fetcher/Cargo.lock
@@ -403,6 +403,7 @@ name = "fetcher"
 version = "0.1.0"
 dependencies = [
  "convert_case",
+ "futures",
  "octocrab",
  "serde",
  "serde_json",
@@ -443,9 +444,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -458,9 +459,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -468,15 +469,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -485,15 +486,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -502,21 +503,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -526,7 +527,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 

--- a/pkgs/fetcher/Cargo.toml
+++ b/pkgs/fetcher/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fetcher"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 convert_case = "0.11.0"

--- a/pkgs/fetcher/Cargo.toml
+++ b/pkgs/fetcher/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-convert_case = "0.11.0"
 futures = "0.3.32"
+heck = "0.5.0"
 octocrab = "0.53.0"
 serde = "1.0.228"
 serde_json = "1.0.149"

--- a/pkgs/fetcher/Cargo.toml
+++ b/pkgs/fetcher/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 convert_case = "0.11.0"
+futures = "0.3.32"
 octocrab = "0.53.0"
 serde = "1.0.228"
 serde_json = "1.0.149"

--- a/pkgs/fetcher/src/main.rs
+++ b/pkgs/fetcher/src/main.rs
@@ -1,11 +1,11 @@
 use convert_case::{Case, Casing};
 use futures::StreamExt as _;
 use octocrab::{
-    models::{repos::Content, Repository},
     Octocrab,
+    models::{Repository, repos::Content},
 };
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use serde_with::{serde_as, OneOrMany};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use serde_with::{OneOrMany, serde_as};
 use std::{
     collections::{HashMap, HashSet},
     fs::File,
@@ -47,7 +47,7 @@ impl FetchURL {
         let prefetched: Prefetch = serde_json::from_str(&String::from_utf8_lossy(&command_stdout))
             .expect("failed to parse nix store prefetch-file output, how did you make this fail?");
 
-        FetchURL {
+        Self {
             url,
             hash: prefetched.hash,
         }
@@ -63,7 +63,8 @@ impl FetchURL {
 
         let prefetched: Prefetch = serde_json::from_str(&String::from_utf8_lossy(&command_stdout))
             .expect("failed to parse nix store prefetch-file output, how did you make this fail?");
-        FetchURL {
+
+        Self {
             url: url.to_string(),
             hash: prefetched.hash,
         }
@@ -386,8 +387,7 @@ where
         for manifest in tuple.manifests.0 {
             let branch = manifest
                 .branch()
-                .map(ToOwned::to_owned)
-                .unwrap_or_else(|| get_default_branch(&tuple.repo));
+                .map_or_else(|| get_default_branch(&tuple.repo), ToOwned::to_owned);
 
             let Some(rev) = get_rev(crab, &owner, name, &branch).await else {
                 continue;

--- a/pkgs/fetcher/src/main.rs
+++ b/pkgs/fetcher/src/main.rs
@@ -1,44 +1,123 @@
 use convert_case::{Case, Casing};
+use futures::StreamExt as _;
 use octocrab::{
     models::{repos::Content, Repository},
     Octocrab,
 };
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_with::{serde_as, OneOrMany};
-use std::path::Path;
-use std::{collections::HashMap, fs::File, process::Command};
-use tokio::join;
+use std::{
+    collections::{HashMap, HashSet},
+    fs::File,
+    process::Command,
+};
 
-#[derive(Serialize, Deserialize)]
+const FETCH_CONCURRENCY: usize = 8;
+
+#[derive(Deserialize)]
 struct Blacklist {
     repos: Vec<String>,
 }
-#[derive(Serialize, Deserialize)]
+
+#[derive(Deserialize)]
 struct Prefetch {
     hash: String,
 }
+
 #[derive(Serialize, Deserialize, Clone)]
 struct FetchURL {
     url: String,
     hash: String,
 }
 
-// Extension
-#[serde_as]
-#[derive(Clone, Serialize, Deserialize, Debug)]
-struct ExtManifests(#[serde_as(as = "OneOrMany<_>")] Vec<ExtManifest>);
+impl FetchURL {
+    fn from_repo(repo: &Repository, rev: &str) -> Self {
+        let url = format!(
+            "{}/archive/{rev}.tar.gz",
+            repo.html_url.as_ref().expect("Epic html_url failure"),
+        );
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+        println!("Hashing: {url}");
+        let command_stdout = Command::new("nix")
+            .args(["store", "prefetch-file", &url, "--unpack", "--json"])
+            .output()
+            .expect("failed to run nix store prefetch-file lol")
+            .stdout;
+
+        let prefetched: Prefetch = serde_json::from_str(&String::from_utf8_lossy(&command_stdout))
+            .expect("failed to parse nix store prefetch-file output, how did you make this fail?");
+
+        FetchURL {
+            url,
+            hash: prefetched.hash,
+        }
+    }
+
+    fn from_url(url: &str) -> Self {
+        println!("Hashing: {url}");
+        let command_stdout = Command::new("nix")
+            .args(["store", "prefetch-file", url, "--unpack", "--json"])
+            .output()
+            .expect("failed to run nix store prefetch-file lol")
+            .stdout;
+
+        let prefetched: Prefetch = serde_json::from_str(&String::from_utf8_lossy(&command_stdout))
+            .expect("failed to parse nix store prefetch-file output, how did you make this fail?");
+        FetchURL {
+            url: url.to_string(),
+            hash: prefetched.hash,
+        }
+    }
+}
+
+trait Manifest {
+    const TAG: &'static str;
+
+    type Output;
+
+    fn name(&self) -> &str;
+    fn branch(&self) -> Option<&str>;
+    fn into_output(self, source: FetchURL) -> Self::Output;
+}
+
+#[serde_as]
+#[derive(Clone, Deserialize, Debug)]
+struct Manifests<T: DeserializeOwned>(#[serde_as(as = "OneOrMany<_>")] Vec<T>);
+
+/// A tuple of a manifest and its corresponding repository.
+struct ManifestTuple<T: DeserializeOwned> {
+    manifests: Manifests<T>,
+    repo: Repository,
+}
+
+// Extension
+#[derive(Clone, Debug, Deserialize)]
 struct ExtManifest {
     name: String,
     main: String,
     branch: Option<String>,
 }
 
-#[derive(Serialize, Deserialize)]
-struct ExtTuple {
-    manifests: ExtManifests,
-    repo: Repository,
+impl Manifest for ExtManifest {
+    const TAG: &'static str = "spicetify-extensions";
+
+    type Output = ExtOutput;
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn branch(&self) -> Option<&str> {
+        self.branch.as_deref()
+    }
+
+    fn into_output(self, source: FetchURL) -> Self::Output {
+        ExtOutput {
+            name: self.main.split('/').next_back().unwrap().to_string(),
+            source,
+            main: self.main,
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize)]
@@ -49,20 +128,31 @@ struct ExtOutput {
 }
 
 // App
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 struct AppManifest {
     name: String,
     branch: Option<String>,
 }
 
-#[serde_as]
-#[derive(Clone, Serialize, Deserialize, Debug)]
-struct AppManifests(#[serde_as(as = "OneOrMany<_>")] Vec<AppManifest>);
+impl Manifest for AppManifest {
+    const TAG: &'static str = "spicetify-apps";
 
-#[derive(Serialize, Deserialize)]
-struct AppTuple {
-    manifests: AppManifests,
-    repo: Repository,
+    type Output = AppOutput;
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn branch(&self) -> Option<&str> {
+        self.branch.as_deref()
+    }
+
+    fn into_output(self, source: FetchURL) -> Self::Output {
+        AppOutput {
+            name: self.name,
+            source,
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize)]
@@ -72,14 +162,7 @@ struct AppOutput {
 }
 
 // Theme
-#[derive(Serialize, Deserialize)]
-#[serde(untagged)]
-enum IncludeEnum {
-    String(String),
-    FetchURL(FetchURL),
-}
-
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 struct ThemeManifest {
     name: String,
     usercss: String,
@@ -88,14 +171,49 @@ struct ThemeManifest {
     branch: Option<String>,
 }
 
-#[serde_as]
-#[derive(Clone, Serialize, Deserialize, Debug)]
-struct ThemeManifests(#[serde_as(as = "OneOrMany<_>")] Vec<ThemeManifest>);
+impl Manifest for ThemeManifest {
+    const TAG: &'static str = "spicetify-themes";
 
-#[derive(Serialize, Deserialize)]
-struct ThemeTuple {
-    manifests: ThemeManifests,
-    repo: Repository,
+    type Output = ThemeOutput;
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn branch(&self) -> Option<&str> {
+        self.branch.as_deref()
+    }
+
+    fn into_output(self, source: FetchURL) -> Self::Output {
+        let include = self
+            .include
+            .unwrap_or_default()
+            .into_iter()
+            .map(|s| {
+                if s.starts_with("http") {
+                    ExtOutput {
+                        name: s.split('/').next_back().unwrap().to_string(),
+                        main: "__INCLUDE__".to_string(),
+                        source: FetchURL::from_url(&s),
+                    }
+                } else {
+                    ExtOutput {
+                        name: s.split('/').next_back().unwrap().to_string(),
+                        main: s,
+                        source: source.clone(),
+                    }
+                }
+            })
+            .collect::<Vec<ExtOutput>>();
+
+        ThemeOutput {
+            name: self.name,
+            source,
+            schemes: self.schemes,
+            usercss: self.usercss,
+            include,
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize)]
@@ -108,18 +226,30 @@ struct ThemeOutput {
 }
 
 // Snippets
-
 #[derive(Serialize, Deserialize)]
 struct Snippet {
     code: String,
     preview: String,
 }
 
+impl Snippet {
+    /// Returns the name of the snippet, derived from the preview file name.
+    fn name(&self) -> String {
+        self.preview
+            .rsplit('/')
+            .next()
+            .unwrap_or(&self.preview)
+            .rsplit('.')
+            .skip(1)
+            .collect()
+    }
+}
+
 #[derive(Serialize, Deserialize)]
 struct Output {
-    //extensions: HashMap<String, ExtOutput>,
-    //apps: HashMap<String, AppOutput>,
-    //themes: HashMap<String, ThemeOutput>,
+    // extensions: HashMap<String, ExtOutput>,
+    // apps: HashMap<String, AppOutput>,
+    // themes: HashMap<String, ThemeOutput>,
     snippets: HashMap<String, String>,
 }
 
@@ -150,298 +280,141 @@ async fn search_tag(crab: &Octocrab, tag: &str) -> Vec<Repository> {
     all_pages
 }
 
-fn filter_tag(blacklist: &[String], tag: Vec<Repository>) -> Vec<Repository> {
-    tag.into_iter()
-        .filter(|x| {
-            !blacklist.contains(
-                &x.html_url
-                    .clone()
-                    .expect("Epic html_url failure")
-                    .to_string(),
-            ) && !x.archived.unwrap_or(false)
-        })
-        .collect()
-}
-
-async fn get_manifest(crab: &Octocrab, repo: &Repository) -> Option<String> {
-    if let Ok(ok) = crab
-        .repos(repo.owner.clone().unwrap().login, repo.clone().name)
-        .get_content()
-        .path("manifest.json")
-        .send()
-        .await
-    {
-        ok.items.first().map_or_else(
-            || {
-                println!(
-                    "Failed to convert manifest.json to string from: {}",
-                    repo.html_url.clone().expect("Epic html_url failure")
-                );
-                None
-            },
-            Content::decoded_content,
-        )
-    } else {
-        println!(
-            "Failed to get manifest.json from: {}",
-            repo.html_url.clone().expect("Epic html_url failure")
-        );
-        None
-    }
-}
-
 fn get_owner(repo: &Repository) -> String {
-    repo.owner.clone().expect("failed to get repo owner?").login
+    repo.owner
+        .as_ref()
+        .map(|o| o.login.clone())
+        .expect("failed to get repo owner?")
 }
 
 fn get_default_branch(repo: &Repository) -> String {
     repo.default_branch
-        .clone()
+        .as_ref()
         .expect("failed to get default_branch")
+        .to_owned()
 }
 
-async fn get_rev(crab: &Octocrab, owner: &str, name: &str, branch: &String) -> Option<String> {
-    if let Ok(x) = crab.commits(owner, name).get(branch.clone()).await {
-        Some(x.sha)
-    } else {
+async fn get_rev(crab: &Octocrab, owner: &str, name: &str, branch: &str) -> Option<String> {
+    let Ok(commit) = crab.commits(owner, name).get(branch).await else {
         println!("Failed to get latest commit of github.com/{owner}/{name} branch: {branch}");
-        None
-    }
+        return None;
+    };
+
+    Some(commit.sha)
 }
 
-fn fetch_url(url: String) -> FetchURL {
-    println!("Hashing: {url}");
-    let command_stdout = Command::new("nix")
-        .args(["store", "prefetch-file", &url, "--json"])
-        .output()
-        .expect("failed to run nix store prefetch-file lol")
-        .stdout;
-    let prefetched: Prefetch = serde_json::from_str(&String::from_utf8_lossy(&command_stdout))
-        .expect("failed to parse nix store prefetch-file output, how did you make this fail?");
+async fn get_manifest(crab: &Octocrab, repo: &Repository) -> Option<String> {
+    let items = crab
+        .repos(repo.owner.as_ref().map(|o| &o.login).unwrap(), &repo.name)
+        .get_content()
+        .path("manifest.json")
+        .send()
+        .await
+        .inspect_err(|_| {
+            println!(
+                "Failed to get manifest.json from: {}",
+                repo.html_url.as_ref().expect("Epic html_url failure")
+            );
+        })
+        .ok()?;
 
-    FetchURL {
-        url,
-        hash: prefetched.hash,
+    if items.items.is_empty() {
+        println!(
+            "Failed to get manifest.json from: {}",
+            repo.html_url.as_ref().expect("Epic html_url failure")
+        );
+        return None;
     }
+
+    items.items.first().and_then(Content::decoded_content)
 }
 
-fn fetch_gh_archive(repo: &Repository, rev: &str) -> FetchURL {
-    let url = format!(
-        "{}/archive/{}.tar.gz",
-        repo.html_url.clone().expect("Epic html_url failure"),
-        rev
-    );
-    println!("Hashing: {url}");
-    let command_stdout = Command::new("nix")
-        .args(["store", "prefetch-file", &url, "--unpack", "--json"])
-        .output()
-        .expect("failed to run nix store prefetch-file lol")
-        .stdout;
-    let prefetched: Prefetch = serde_json::from_str(&String::from_utf8_lossy(&command_stdout))
-        .expect("failed to parse nix store prefetch-file output, how did you make this fail?");
-    FetchURL {
-        url,
-        hash: prefetched.hash,
-    }
-}
+async fn fetch_tuples<T>(
+    crab: &Octocrab,
+    repos: impl IntoIterator<Item = Repository>,
+) -> impl Iterator<Item = ManifestTuple<T>>
+where
+    T: DeserializeOwned,
+{
+    // fetch up to `FETCH_CONCURRENCY` manifests concurrently
+    futures::stream::iter(repos.into_iter().map(|repo| async move {
+        let manifest_json = get_manifest(crab, &repo).await?;
 
-async fn extensions(crab: &Octocrab, blacklist: &[String]) -> HashMap<String, ExtOutput> {
-    let mut potato: HashMap<String, FetchURL> = HashMap::new();
-    let extensions: Vec<Repository> =
-        filter_tag(blacklist, search_tag(crab, "spicetify-extensions").await);
-
-    let mut ext_tuple: Vec<ExtTuple> = vec![];
-
-    for i in extensions {
-        let Some(manifest) = get_manifest(crab, &i).await else {
-            continue;
+        let Ok(manifests) = serde_json::from_str::<Manifests<T>>(&manifest_json) else {
+            println!(
+                "Failed to parse manifest from: {}",
+                repo.html_url.as_ref().expect("Epic html_url failure")
+            );
+            return None;
         };
 
-        let parse: ExtManifests = if let Ok(ok) = serde_json::from_str(&manifest) {
-            ok
-        } else {
-            println!("Failed to parse manifest from: {}", i.html_url.unwrap());
+        Some(ManifestTuple::<T> { manifests, repo })
+    }))
+    .buffer_unordered(FETCH_CONCURRENCY)
+    .collect::<Vec<_>>()
+    .await
+    .into_iter()
+    .flatten()
+}
 
-            continue;
-        };
+async fn collect_outputs<M>(
+    crab: &Octocrab,
+    blacklist: &HashSet<String>,
+) -> HashMap<String, M::Output>
+where
+    M: Manifest + DeserializeOwned,
+{
+    let repos = search_tag(crab, M::TAG).await.into_iter().filter(|repo| {
+        !blacklist.contains(
+            &repo
+                .html_url
+                .as_ref()
+                .expect("Epic html_url failure")
+                .to_string(),
+        ) && !repo.archived.unwrap_or(false)
+    });
 
-        ext_tuple.push(ExtTuple {
-            manifests: parse,
-            repo: i,
-        });
-    }
-    let mut ext_outputs: HashMap<String, ExtOutput> = HashMap::new();
-    for i in ext_tuple {
-        let owner = &get_owner(&i.repo);
-        let name = &i.repo.name;
+    let tuples = fetch_tuples::<M>(crab, repos).await;
 
-        for j in i.manifests.0 {
-            let branch = j.branch.unwrap_or_else(|| get_default_branch(&i.repo));
+    let mut prefetch_cache: HashMap<String, FetchURL> = HashMap::new();
+    let mut outputs = HashMap::new();
 
-            let Some(rev) = get_rev(crab, owner, name, &branch).await else {
+    for tuple in tuples {
+        let owner = get_owner(&tuple.repo);
+        let name = &tuple.repo.name;
+
+        for manifest in tuple.manifests.0 {
+            let branch = manifest
+                .branch()
+                .map(ToOwned::to_owned)
+                .unwrap_or_else(|| get_default_branch(&tuple.repo));
+
+            let Some(rev) = get_rev(crab, &owner, name, &branch).await else {
                 continue;
             };
 
             let key = format!("{owner}-{name}-{branch}");
+            let source = prefetch_cache
+                .entry(key)
+                .or_insert_with(|| FetchURL::from_repo(&tuple.repo, &rev))
+                .clone();
 
-            if !potato.contains_key(&key) {
-                potato.insert(key.clone(), fetch_gh_archive(&i.repo, &rev));
-            }
-
-            ext_outputs.insert(
-                sanitize_name(&j.name),
-                ExtOutput {
-                    name: j.main.split('/').next_back().unwrap().to_string(),
-                    source: potato.get(&key).unwrap().clone(),
-                    main: j.main,
-                },
-            );
+            let output_name = sanitize_name(manifest.name());
+            outputs.insert(output_name, manifest.into_output(source));
         }
     }
 
-    ext_outputs
-}
-
-async fn apps(crab: &Octocrab, blacklist: &[String]) -> HashMap<String, AppOutput> {
-    let mut potato: HashMap<String, FetchURL> = HashMap::new();
-    let apps: Vec<Repository> = filter_tag(blacklist, search_tag(crab, "spicetify-apps").await);
-
-    let mut app_tuple: Vec<AppTuple> = vec![];
-    for i in apps {
-        let Some(manifest) = get_manifest(crab, &i).await else {
-            continue;
-        };
-
-        let parse: AppManifests = if let Ok(ok) = serde_json::from_str(&manifest) {
-            ok
-        } else {
-            println!("Failed to parse manifest from: {}", i.html_url.unwrap());
-            continue;
-        };
-
-        app_tuple.push(AppTuple {
-            manifests: parse,
-            repo: i,
-        });
-    }
-
-    let mut app_outputs: HashMap<String, AppOutput> = HashMap::new();
-
-    for i in app_tuple {
-        let owner = &get_owner(&i.repo);
-        let name = &i.repo.name;
-
-        for j in i.manifests.0 {
-            let branch = j.branch.unwrap_or_else(|| get_default_branch(&i.repo));
-
-            let Some(rev) = get_rev(crab, owner, name, &branch).await else {
-                continue;
-            };
-
-            let key = format!("{owner}-{name}-{branch}");
-
-            if !potato.contains_key(&key) {
-                potato.insert(key.clone(), fetch_gh_archive(&i.repo, &rev));
-            }
-
-            app_outputs.insert(
-                sanitize_name(&j.name),
-                AppOutput {
-                    name: j.name,
-                    source: potato.get(&key).unwrap().clone(),
-                },
-            );
-        }
-    }
-
-    app_outputs
-}
-
-async fn themes(crab: &Octocrab, blacklist: &[String]) -> HashMap<String, ThemeOutput> {
-    let mut potato: HashMap<String, FetchURL> = HashMap::new();
-    let themes: Vec<Repository> = filter_tag(blacklist, search_tag(crab, "spicetify-themes").await);
-
-    let mut theme_tuple: Vec<ThemeTuple> = vec![];
-    for i in themes {
-        let Some(manifest) = get_manifest(crab, &i).await else {
-            continue;
-        };
-
-        let parse: ThemeManifests = if let Ok(ok) = serde_json::from_str(&manifest) {
-            ok
-        } else {
-            println!("Failed to parse manifest from: {}", i.html_url.unwrap());
-
-            continue;
-        };
-
-        theme_tuple.push(ThemeTuple {
-            manifests: parse,
-            repo: i,
-        });
-    }
-
-    let mut theme_outputs: HashMap<String, ThemeOutput> = HashMap::new();
-
-    for i in theme_tuple {
-        let owner = &get_owner(&i.repo);
-        let name = &i.repo.name;
-
-        for j in i.manifests.0 {
-            let branch = j.branch.unwrap_or_else(|| get_default_branch(&i.repo));
-
-            let Some(rev) = get_rev(crab, owner, name, &branch).await else {
-                continue;
-            };
-
-            let key = format!("{owner}-{name}-{branch}");
-
-            if !potato.contains_key(&key) {
-                potato.insert(key.clone(), fetch_gh_archive(&i.repo, &rev));
-            }
-
-            theme_outputs.insert(
-                sanitize_name(&j.name),
-                ThemeOutput {
-                    name: j.name.clone(),
-                    source: potato.get(&key).unwrap().clone(),
-                    schemes: j.schemes,
-                    usercss: j.usercss,
-                    include: j.include.map_or_else(std::vec::Vec::new, |x| {
-                        let mut val: Vec<ExtOutput> = vec![];
-                        for s in x {
-                            if s.starts_with("http") {
-                                val.push(ExtOutput {
-                                    name: s.split('/').next_back().unwrap().to_string(),
-                                    main: "__INCLUDE__".to_string(),
-                                    source: fetch_url(s),
-                                });
-                            } else {
-                                val.push(ExtOutput {
-                                    name: s.split('/').next_back().unwrap().to_string(),
-                                    main: s.clone(),
-                                    source: potato.get(&key).unwrap().clone(),
-                                });
-                            }
-                        }
-                        val
-                    }),
-                },
-            );
-        }
-    }
-
-    theme_outputs
+    outputs
 }
 
 #[tokio::main]
 async fn main() {
-    let crab: Octocrab = octocrab::Octocrab::builder()
+    let crab = Octocrab::builder()
         .personal_token(std::env::var("GITHUB_TOKEN").expect("no PAT key moron"))
         .build()
         .expect("Failed to crab");
 
-    let blacklist = crab
+    let blacklist_json = crab
         .repos("spicetify", "marketplace")
         .get_content()
         .path("resources/blacklist.json")
@@ -452,10 +425,15 @@ async fn main() {
         .items
         .first()
         .unwrap()
-        .decoded_content();
+        .decoded_content()
+        .expect("Failed to read blacklist");
 
-    let vector: Blacklist = serde_json::from_str(&blacklist.expect("Failed to read blacklist"))
-        .expect("Failed to parse blacklist");
+    let _blacklist: HashSet<String> = HashSet::from_iter(
+        serde_json::from_str::<Blacklist>(&blacklist_json)
+            .expect("Failed to parse blacklist")
+            .repos,
+    );
+
     let snippets_json = crab
         .repos("spicetify", "marketplace")
         .get_content()
@@ -467,34 +445,30 @@ async fn main() {
         .items
         .first()
         .unwrap()
-        .decoded_content();
+        .decoded_content()
+        .expect("Failed to read snippets.json");
+
     let snippets_vec: Vec<Snippet> =
-        serde_json::from_str(&snippets_json.expect("Failed to read snippets.json"))
-            .expect("Failed to parse snippets.json");
+        serde_json::from_str(&snippets_json).expect("Failed to parse snippets.json");
 
-    let mut snippets_output: HashMap<String, String> = HashMap::new();
+    let snippets_output: HashMap<String, String> = snippets_vec
+        .into_iter()
+        .map(|i| {
+            let name = i.name();
+            (sanitize_name(&name), i.code)
+        })
+        .collect();
 
-    for i in snippets_vec {
-        // i hate strings
-        let name = Path::new(&i.preview)
-            .file_stem()
-            .unwrap()
-            .to_os_string()
-            .into_string()
-            .unwrap();
-        snippets_output.insert(sanitize_name(&name), i.code);
-    }
-
-    //let extensions = extensions(&crab, &vector.repos);
-    //let apps = apps(&crab, &vector.repos);
-    //let themes = themes(&crab, &vector.repos);
+    // let extensions = collect_outputs::<ExtManifest>(&crab, &_blacklist);
+    // let apps = collect_outputs::<AppManifest>(&crab, &_blacklist);
+    // let themes = collect_outputs::<ThemeManifest>(&crab, &_blacklist);
     // Theme stuff
-    //let output = join!(extensions, apps, themes);
+    // let output = join!(extensions, apps, themes);
 
-    let final_output: Output = Output {
-        //extensions: output.0,
-        //apps: output.1,
-        //themes: output.2,
+    let final_output = Output {
+        // extensions: output.0,
+        // apps: output.1,
+        // themes: output.2,
         snippets: snippets_output,
     };
 

--- a/pkgs/fetcher/src/main.rs
+++ b/pkgs/fetcher/src/main.rs
@@ -1,5 +1,5 @@
-use convert_case::{Case, Casing};
 use futures::StreamExt as _;
+use heck::ToLowerCamelCase;
 use octocrab::{
     Octocrab,
     models::{Repository, repos::Content},
@@ -254,9 +254,10 @@ struct Output {
     snippets: HashMap<String, String>,
 }
 
-fn sanitize_name(name: &str) -> String {
-    name.to_case(Case::Camel)
-        .replace(|c| !char::is_alphanumeric(c), "")
+fn sanitize_name(name: impl AsRef<str>) -> String {
+    name.as_ref()
+        .to_lower_camel_case()
+        .replace(|c: char| !c.is_ascii_alphanumeric(), "")
 }
 
 async fn search_tag(crab: &Octocrab, tag: &str) -> Vec<Repository> {


### PR DESCRIPTION
this does a few things:

- extract the fetching logic into functions
- fetch up to 8 manifests concurrently per "type", tunable via `FETCH_CONCURRENCY`
- less allocations everywhere (mostly avoiding clones and `Vec`s when not necessary)
- replace `convert_case` dep with the more commonly used `heck`, which was already in the tree
- clippy and fmt

if this makes the code too "rusty" so that it's hard to maintain, let me know and i'll try to figure something out :)

i tested this by running `nix run .#fetcher` with all of the outputs, but i didn't include the generated json since that's done in CI