### PR TITLE
fix(comfy): avoid injecting theme script twice

### DIFF
--- a/pkgs/themes.nix
+++ b/pkgs/themes.nix
@@ -216,6 +216,9 @@
       name = "Comfy";
       src = "${sources.comfySrc}/Comfy";
 
+      # theme.js is registered below as a required extension.
+      injectThemeJs = false;
+
       overwriteAssets = true;
 
       requiredExtensions = [


### PR DESCRIPTION
Comfy registers `theme.js` through `requiredExtensions`, but the default `injectThemeJs = true` also causes Spicetify to load the same file as the theme script.

Disabling the automatic theme-script injection leaves the required extension as the single source of truth and prevents duplicate top-bar settings buttons.

Validated by evaluating the Comfy theme on `aarch64-darwin` and confirming `injectThemeJs = false`.