### PR TITLE
treewide: stdenv.is* -> stdenv.hostPlatform.is*

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -11,7 +11,7 @@
           (import ../modules/options.nix self)
           module
         ]
-        ++ lib.optional pkgs.stdenv.isLinux ../modules/linuxOpts.nix;
+        ++ lib.optional pkgs.stdenv.hostPlatform.isLinux ../modules/linuxOpts.nix;
       };
       failedAssertions = map (x: x.message) (builtins.filter (x: !x.assertion) evaled.config.assertions);
       baseSystemAssertWarn =

--- a/modules/common.nix
+++ b/modules/common.nix
@@ -12,7 +12,7 @@ self:
       modules = [
         (import ./options.nix self)
       ]
-      ++ lib.optional pkgs.stdenv.isLinux ./linuxOpts.nix;
+      ++ lib.optional pkgs.stdenv.hostPlatform.isLinux ./linuxOpts.nix;
     };
     default = { };
   };

--- a/modules/options.nix
+++ b/modules/options.nix
@@ -344,10 +344,10 @@ in
             # compose the configuration as well as options required by extensions and
             # config.config.xpui into one set
             config-xpui = xpui;
-            wayland = if pkgs.stdenv.isLinux then config.wayland else null;
+            wayland = if pkgs.stdenv.hostPlatform.isLinux then config.wayland else null;
           };
         in
-        if pkgs.stdenv.isLinux && config.windowManagerPatch then
+        if pkgs.stdenv.hostPlatform.isLinux && config.windowManagerPatch then
           (config.spotifywmPackage.override { spotify = spicedSpotify'; }).overrideAttrs (old: {
             passthru = (old.passthru or { }) // spicedSpotify'.passthru;
           })

--- a/pkgs/spicetifyBuilder.nix
+++ b/pkgs/spicetifyBuilder.nix
@@ -72,9 +72,9 @@ lib.makeOverridable (
 
           # replace the spotify path with the current derivation's path
           sed "s|__SPOTIFY__|${
-            if stdenv.isLinux then
+            if stdenv.hostPlatform.isLinux then
               "$out/share/spotify"
-            else if stdenv.isDarwin then
+            else if stdenv.hostPlatform.isDarwin then
               "$out/Applications/Spotify.app/Contents/Resources"
             else
               throw ""
@@ -87,7 +87,7 @@ lib.makeOverridable (
           ${lib.getExe spicetify-cli} --no-restart backup apply
         '';
       }
-      // lib.optionalAttrs (stdenv.isLinux && wayland != null) {
+      // lib.optionalAttrs (stdenv.hostPlatform.isLinux && wayland != null) {
 
         fixupPhase = ''
           runHook preFixup


### PR DESCRIPTION
Nixpkgs deprecated the former.